### PR TITLE
Add: 推しメンの情報を取得するシリアライザーに返却するカラム追加

### DIFF
--- a/app/controllers/api/v1/user/recommended_members_controller.rb
+++ b/app/controllers/api/v1/user/recommended_members_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::User::RecommendedMembersController < SecuredController
 
   def index
     authorize([:user, RecommendedMember])
-    recommended_members = current_user.recommended_members.all
+    recommended_members = current_user.recommended_members.all.preload(:diaries)
     render_json = User::RecommendedMemberSerializer.new(recommended_members).serializable_hash.to_json
     render json: render_json, status: :ok
   end

--- a/app/serializers/user/recommended_member_serializer.rb
+++ b/app/serializers/user/recommended_member_serializer.rb
@@ -2,5 +2,12 @@ class User::RecommendedMemberSerializer
   include JSONAPI::Serializer
   attributes :id, :uuid, :nickname, :group, :first_met_date
 
+  attribute :total_member_polaroid_count do |object|
+    count = 0
+    object.diaries.each do |diary|
+      count += diary.event_polaroid_count || 0
+    end
+    count
+  end
   # チェキ総数、登録した日記、出会ってから経過した日数
 end

--- a/app/serializers/user/recommended_member_serializer.rb
+++ b/app/serializers/user/recommended_member_serializer.rb
@@ -9,5 +9,9 @@ class User::RecommendedMemberSerializer
     end
     count
   end
-  # チェキ総数、登録した日記、出会ってから経過した日数
+
+  attributes :diaries_count do |object|
+    object.diaries.count
+  end
+  # 出会ってから経過した日数
 end


### PR DESCRIPTION
## 変更の概要

具体的には以下の値

- チェキ総数

- 登録した日記数

### 関連するissue

## なぜこの変更をするのか

* 変更をする理由
* 前提知識がなくても分かるようにする

## やったこと

- [x]  推しメンとのチェキ総数のカラムをシリアライザーに追加
- [x] 登録した日記数を返すカラムをシリアライザーに追加



## 備考

* その他に伝えたいこと
