### PR TITLE
日記に紐付ける画像を同時に保存する機能追加

### DIFF
--- a/app/controllers/api/v1/user/diaries_controller.rb
+++ b/app/controllers/api/v1/user/diaries_controller.rb
@@ -13,9 +13,6 @@ class Api::V1::User::DiariesController < SecuredController
     ActiveRecord::Base.transaction do
       diary = current_user.recommended_members.find_by!(id: params[:recommended_member_id]).diaries.build(diary_params)
       diary.save!
-      # Bulk INSERTを使って複数のイメージを保存
-      diary_image = diary.diary_images.build(diary_image_url: params[:diary][:diary_image_url])
-      diary_image.save!
     end
     head :ok
   end
@@ -42,12 +39,12 @@ class Api::V1::User::DiariesController < SecuredController
 
   def diary_params
     params.require(:diary).permit(:event_name, :event_date, :event_venue, :event_polaroid_count,
-                                  :impressive_memory, :impressive_memory_detail, :status, :diary_image_url).merge(user_id: current_user.id)
+                                  :impressive_memory, :impressive_memory_detail, :status, diary_images_attributes:[:diary_image_url]).merge(user_id: current_user.id)
   end
 
   def diary_update_params
     params.require(:diary).permit(:event_name, :event_date, :event_venue, :event_polaroid_count,
-                                  :impressive_memory, :impressive_memory_detail, :status, :diary_image_url)
+                                  :impressive_memory, :impressive_memory_detail, :status)
   end
 
   def set_diary

--- a/app/controllers/api/v1/user/diaries_controller.rb
+++ b/app/controllers/api/v1/user/diaries_controller.rb
@@ -39,7 +39,7 @@ class Api::V1::User::DiariesController < SecuredController
 
   def diary_params
     params.require(:diary).permit(:event_name, :event_date, :event_venue, :event_polaroid_count,
-                                  :impressive_memory, :impressive_memory_detail, :status, diary_images_attributes:[:diary_image_url]).merge(user_id: current_user.id)
+                                  :impressive_memory, :impressive_memory_detail, :status, diary_images_attributes: [:diary_image_url]).merge(user_id: current_user.id)
   end
 
   def diary_update_params


### PR DESCRIPTION
## 変更の概要

日記の保存と同時にそれに紐づける画像も保存するようにダイアリーコントローラーのストパラを変更

### 関連するissue

## なぜこの変更をするのか

* 変更をする理由
* 前提知識がなくても分かるようにする

## やったこと

- [x] 日記の保存と同時にそれに紐づける画像も保存するようにダイアリーコントローラーのストパラを変更

## 変更内容

* UIの変更ならスクリーンショット
* APIの変更ならリクエストとレスポンス

## 影響範囲

* ユーザに影響すること
* メンバーに影響すること
* システムに影響すること

## どうやるのか

* 使い方
* 再現手順

## 課題

* 悩んでいること
* とくにレビューしてほしいところ

## 備考

* その他に伝えたいこと
