### PR TITLE
Add: 一般ユーザーが見れる日記のAPIを追加

### DIFF
--- a/app/controllers/api/v1/diaries_controller.rb
+++ b/app/controllers/api/v1/diaries_controller.rb
@@ -1,14 +1,13 @@
 class Api::V1::DiariesController < ApplicationController
   def index
     diaries = Diary.all.published.eager_load(:recommended_member, :user).preload(:diary_images)
-    # .preload(:diary_images).eager_load(:recommended_member, :user).order(event_date: :desc)
     render_json = DiaryListSerializer.new(diaries).serializable_hash.to_json
     render json: render_json, status: :ok
   end
 
   def show
-    diary = Diary.find_by(uuid: params[:uuid])
-    render_json = DiaryListSerializer.new(diary).serializable_hash.to_json
+    diary = Diary.find_by!(id: params[:id])
+    render_json = DiaryDetailSerializer.new(diary).serializable_hash.to_json
     render json: render_json, status: :ok
   end
 end

--- a/app/serializers/diary_detail_serializer.rb
+++ b/app/serializers/diary_detail_serializer.rb
@@ -1,6 +1,5 @@
 class DiaryDetailSerializer
   include JSONAPI::Serializer
-  # 画像のURLも必要
   attributes :id, :uuid, :event_name, :event_date, :event_venue, :event_polaroid_count, :impressive_memory, :impressive_memory_detail
 
   attribute :diary_user do |object|

--- a/app/serializers/user/diary_detail_serializer.rb
+++ b/app/serializers/user/diary_detail_serializer.rb
@@ -1,6 +1,5 @@
 class User::DiaryDetailSerializer
   include JSONAPI::Serializer
-  # 画像のURLも必要
   attributes :id, :uuid, :event_name, :event_date, :event_venue, :event_polaroid_count, :impressive_memory, :impressive_memory_detail
 
   attribute :diary_user do |object|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
         get 'user_info', on: :collection
         delete 'destroy', on: :collection
       end
-      resources :diaries, only: [:index, :show], param: :uuid
+      resources :diaries, only: [:index, :show]
       namespace :user do
         resources :recommended_members, shallow: true do
           resources :diaries

--- a/spec/requests/api/v1/diaries_spec.rb
+++ b/spec/requests/api/v1/diaries_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "非ログインユーザーの日記閲覧機能", type: :reques
 
   describe "非ログインユーザーが日記の詳細を閲覧できること GET /api/v1/diaries" do
     let!(:diary) { create(:diary, :published) }
-    let(:http_request) { get api_v1_diary_path(diary.uuid), headers: headers }
+    let(:http_request) { get api_v1_diary_path(diary.id), headers: headers }
     it "非ログインユーザーがが日記の詳細を閲覧できること" do
       http_request
       expect(response).to be_successful


### PR DESCRIPTION
## 変更の概要

一般ユーザーが見れる日記のAPIを追加
動的OGPのURLを開いた際のデータを取得するためのAPIになる。



## どうやるのか



## 課題



## 備考

* その他に伝えたいこと
