### PR TITLE
Add: テストカバレッジをCodeClimateに送信する処理を追加

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
             chmod +x ./cc-test-reporter
       - run:
           command: |
-            ./cc-test-reporter sum-coverage --output - codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
+            ./cc-test-reporter sum-coverage --output - codeclimate.$CIRCLE_NODE_INDEX.json | ./cc-test-reporter upload-coverage --debug --input -
 
   rubocop:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
       - persist_to_workspace:
           root: coverage
           paths:
-            - codeclimate.*.json
+            - coverage/codeclimate.$CIRCLE_NODE_INDEX.json
       - store_test_results:
           path: tmp/test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,3 +148,6 @@ workflows:
       - rubocop:
           requires:
             - bundle_dependencies
+      - upload-coverage:
+          requires:
+            - rspec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,9 @@ jobs:
     executor:
       name: backend_container
     steps:
+      # persist_to_workspaceをアタッチ
+      - attach_workspace:
+          at: ~/backend
       - restore_cache:
           key: v1-backend-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:
@@ -121,9 +124,6 @@ jobs:
     executor:
       name: backend_container
     steps:
-      # persist_to_workspaceをアタッチ
-      - attach_workspace:
-          at: ~/backend
       - restore_cache:
           key: v1-backend-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,37 @@ jobs:
           command: |
             TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings --timings-type=filename)
             bundle exec rspec --format progress --format RspecJunitFormatter -o tmp/test-results/rspec.xml -- $TESTFILES
+      # テストカバレッジレポートを作成
+      - run:
+          name: Code Climate Test Coverage
+          command: |
+            ./cc-test-reporter format-coverage -t simplecov -o "coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
+      # 別のjobでも使用できるファイルを指定。rootにはworking_directory:からの相対パス、pathには共有するファイル。
+      - persist_to_workspace:
+          root: coverage
+          paths:
+            - codeclimate.*.json
       - store_test_results:
           path: tmp/test-results
+      - store_artifacts:
+          path: test-artifacts
+
+  upload-coverage:
+    executor:
+      name: backend_container
+    steps:
+      - restore_cache:
+          key: v1-backend-{{ .Environment.CIRCLE_SHA1 }}
+      - restore_cache:
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Install Code Climate Test Reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+      - run:
+          command: |
+            ./cc-test-reporter sum-coverage --output - codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
 
   rubocop:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,11 @@ jobs:
       - restore_cache:
           key: v1-dependencies-{{ checksum "Gemfile.lock" }}
       - run:
+          name: Install Code Climate Test Reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+      - run:
           name: Waiting stand up database
           command: |
             dockerize -wait \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ executors:
     docker:
       - image: cimg/ruby:2.7.4
         environment:
+          CC_TEST_REPORTER_ID: 5df56710761ce8545b8cf471f6fc0be0870c8eab3bbbb7d4776e072fd638b037
           BUNDLER_VERSION: 2.1.4
           RAILS_ENV: 'test'
           DB_HOST: 127.0.0.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
       - persist_to_workspace:
           root: coverage
           paths:
-            - coverage/codeclimate.$CIRCLE_NODE_INDEX.json
+            - codeclimate.*.json
       - store_test_results:
           path: tmp/test-results
       - store_artifacts:
@@ -115,12 +115,15 @@ jobs:
             chmod +x ./cc-test-reporter
       - run:
           command: |
-            ./cc-test-reporter sum-coverage --output - codeclimate.$CIRCLE_NODE_INDEX.json | ./cc-test-reporter upload-coverage --debug --input -
+            ./cc-test-reporter sum-coverage --output - codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
 
   rubocop:
     executor:
       name: backend_container
     steps:
+      # persist_to_workspaceをアタッチ
+      - attach_workspace:
+          at: ~/backend
       - restore_cache:
           key: v1-backend-{{ .Environment.CIRCLE_SHA1 }}
       - restore_cache:

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-repo_token: Rb6LAqxCbdKkSf9owBiRDBBYPHrAg0SQe

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@
 
 # irb
 .irb_history
+
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 4.1.0'
 	gem 'factory_bot_rails'
   gem 'rspec_junit_formatter', '~> 0.5.1'
+  gem 'simplecov', require: false, group: :test
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ group :development, :test do
   gem 'rspec-rails', '~> 4.1.0'
 	gem 'factory_bot_rails'
   gem 'rspec_junit_formatter', '~> 0.5.1'
-  gem 'coveralls', require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
     concurrent-ruby (1.1.10)
     crass (1.0.6)
     diff-lcs (1.5.0)
+    docile (1.4.0)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
@@ -106,6 +107,7 @@ GEM
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.1)
+    json (2.6.2)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
     jwt (2.4.1)
@@ -138,7 +140,7 @@ GEM
     rack (2.2.3.1)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
-    rack-test (2.0.0)
+    rack-test (2.0.2)
       rack (>= 1.3)
     rails (6.1.6)
       actioncable (= 6.1.6)
@@ -193,7 +195,8 @@ GEM
     rspec-support (3.11.0)
     rspec_junit_formatter (0.5.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.30.1)
+    rubocop (1.31.1)
+      json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
@@ -207,7 +210,7 @@ GEM
     rubocop-performance (1.14.2)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.15.0)
+    rubocop-rails (2.15.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
@@ -215,8 +218,14 @@ GEM
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    simplecov (0.21.2)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     spring (4.0.0)
-    sprockets (4.1.0)
+    sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.4.2)
@@ -261,6 +270,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  simplecov
   spring
   tzinfo-data
   unicorn

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,9 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'simplecov'
 RSpec.configure do |config|
+  SimpleCov.start 'rails'
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,6 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
-require 'coveralls'
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
@@ -91,5 +90,4 @@ RSpec.configure do |config|
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
 
-Coveralls.wear!
 end


### PR DESCRIPTION
## 変更の概要
テストカバレッジをCodeClimateに送信する処理を追加

以下の`.circleci/config.yml`に以下のjobを追加している

```yaml
  upload-coverage:
    executor:
      name: backend_container
    steps:
      # persist_to_workspaceをアタッチ
      - attach_workspace:
          at: ~/backend
      - restore_cache:
          key: v1-backend-{{ .Environment.CIRCLE_SHA1 }}
      - restore_cache:
          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
      - run:
          name: Install Code Climate Test Reporter
          command: |
            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
            chmod +x ./cc-test-reporter
      - run:
          command: |
            ./cc-test-reporter sum-coverage --output - codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
```

